### PR TITLE
use latest erlang from erlang-solutions

### DIFF
--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -11,9 +11,15 @@ RUN groupadd -r couchdb && useradd -d /var/lib/couchdb -g couchdb couchdb
 # download dependencies, compile and install couchdb
 RUN apt-get update -y \
   && apt-get install -y --no-install-recommends \
-    erlang-nox erlang-dev build-essential ca-certificates curl \
-    libmozjs185-dev libmozjs185-1.0 libnspr4 libnspr4-0d libnspr4-dev libcurl4-openssl-dev libicu-dev \
-  && curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+    build-essential ca-certificates curl \
+    libmozjs185-dev libmozjs185-1.0 libnspr4 libnspr4-0d libnspr4-dev libcurl4-openssl-dev libicu-dev
+
+RUN curl -ssL https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -o esl.deb \
+  && dpkg -i esl.deb && apt-get update
+
+RUN apt-get install -y --no-install-recommends erlang-nox erlang-dev
+
+RUN curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
   && curl -sSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
   && curl -sSL https://www.apache.org/dist/couchdb/KEYS -o KEYS \
   && gpg --import KEYS && gpg --verify couchdb.tar.gz.asc \

--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y \
     build-essential ca-certificates curl \
     libmozjs185-dev libmozjs185-1.0 libnspr4 libnspr4-0d libnspr4-dev libcurl4-openssl-dev libicu-dev \
   && curl -ssL https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -o esl.deb && dpkg -i esl.deb && apt-get update \
-  && apt-get install -y --no-install-recommends erlang-nox erlang-dev \
+  && apt-get install -y --no-install-recommends erlang-nox=1:17.4 erlang-dev=1:17.4 \
   && curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
   && curl -sSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
   && curl -sSL https://www.apache.org/dist/couchdb/KEYS -o KEYS \

--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -12,14 +12,10 @@ RUN groupadd -r couchdb && useradd -d /var/lib/couchdb -g couchdb couchdb
 RUN apt-get update -y \
   && apt-get install -y --no-install-recommends \
     build-essential ca-certificates curl \
-    libmozjs185-dev libmozjs185-1.0 libnspr4 libnspr4-0d libnspr4-dev libcurl4-openssl-dev libicu-dev
-
-RUN curl -ssL https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -o esl.deb \
-  && dpkg -i esl.deb && apt-get update
-
-RUN apt-get install -y --no-install-recommends erlang-nox erlang-dev
-
-RUN curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+    libmozjs185-dev libmozjs185-1.0 libnspr4 libnspr4-0d libnspr4-dev libcurl4-openssl-dev libicu-dev \
+  && curl -ssL https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -o esl.deb && dpkg -i esl.deb && apt-get update \
+  && apt-get install -y --no-install-recommends erlang-nox erlang-dev \
+  && curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
   && curl -sSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
   && curl -sSL https://www.apache.org/dist/couchdb/KEYS -o KEYS \
   && gpg --import KEYS && gpg --verify couchdb.tar.gz.asc \
@@ -31,7 +27,7 @@ RUN curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache
   && apt-get purge -y perl binutils cpp make build-essential libnspr4-dev libcurl4-openssl-dev libicu-dev \
   && apt-get autoremove -y \
   && apt-get update && apt-get install -y libicu48 --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* /usr/src/couchdb /couchdb.tar.gz* /KEYS
+  && rm -rf /var/lib/apt/lists/* /usr/src/couchdb /couchdb.tar.gz* /KEYS /esl.deb
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pgp.mit.edu --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \


### PR DESCRIPTION
Concerning #12 

This fetches erlang 17.4 from erlang-solutions. I can't for the love of god get it to install 16.b.3-3.
Is 17.4 okay or does anyone know how to install the other version?