### PR TITLE
Slight change to Dockerfile to ensure gpg is already setup

### DIFF
--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update -y \
   && rm -rf /var/lib/apt/lists/* /usr/src/couchdb /couchdb.tar.gz* /KEYS
 
 # grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+RUN gpg --list-keys >/dev/null && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
   && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
   && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
   && gpg --verify /usr/local/bin/gosu.asc \


### PR DESCRIPTION
When building our own copy of this, it looked like an issue occurred because gpg wasn't setup when the first command was run.

Solution was to add "gpg --list-keys" before any other gpg actions.