### PR TITLE
Update Erlang dependencies to version 17.5.3

### DIFF
--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y \
     build-essential ca-certificates curl \
     libmozjs185-dev libmozjs185-1.0 libnspr4 libnspr4-0d libnspr4-dev libcurl4-openssl-dev libicu-dev \
   && curl -ssL https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -o esl.deb && dpkg -i esl.deb && apt-get update \
-  && apt-get install -y --no-install-recommends erlang-nox=1:17.4 erlang-dev=1:17.4 \
+  && apt-get install -y --no-install-recommends erlang-nox=1:17.5.3 erlang-dev=1:17.5.3 \
   && curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
   && curl -sSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
   && curl -sSL https://www.apache.org/dist/couchdb/KEYS -o KEYS \


### PR DESCRIPTION
As of 27/05/2015, when you try building a Docker image with CouchDB 1.6.1, you get the following error:

> The following packages have unmet dependencies:
> erlang-dev : Depends: erlang-base (= 1:17.4) but 1:17.5.3 is to be installed or
>                       erlang-base-hipe (= 1:17.4)
> E: Unable to correct problems, you have held broken packages.

This patch fixes the issue and allows you to complete the build process.