### PR TITLE
Update to debian:jessie to fix doc build

### DIFF
--- a/2.0-dev/Dockerfile
+++ b/2.0-dev/Dockerfile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-FROM debian:wheezy
+FROM debian:jessie
 
 MAINTAINER Clemens Stolle klaemo@fastmail.fm
 
@@ -23,15 +23,17 @@ RUN apt-get update -y \
   && apt-get install -y --no-install-recommends build-essential libmozjs185-dev \
     libnspr4 libnspr4-0d libnspr4-dev libcurl4-openssl-dev libicu-dev \
     openssl curl ca-certificates git pkg-config \
-    apt-transport-https python wget
+    apt-transport-https python wget \
+    python-sphinx texlive-base texinfo texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra #needed to build the doc
 
-RUN wget http://packages.erlang-solutions.com/erlang/esl-erlang/FLAVOUR_1_general/esl-erlang_18.0-1~debian~wheezy_amd64.deb
-RUN apt-get install -y --no-install-recommends libwxgtk2.8 default-jdk
+
+RUN wget http://packages.erlang-solutions.com/erlang/esl-erlang/FLAVOUR_1_general/esl-erlang_18.0-1~debian~jessie_amd64.deb
+RUN apt-get install -y --no-install-recommends libwxgtk3.0 default-jdk
 RUN apt-get install -y --no-install-recommends procps
 RUN wget http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
 RUN dpkg -i libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
 
-RUN dpkg -i esl-erlang_18.0-1~debian~wheezy_amd64.deb
+RUN dpkg -i esl-erlang_18.0-1~debian~jessie_amd64.deb
 
 RUN git clone https://github.com/rebar/rebar /usr/src/rebar \
  && (cd /usr/src/rebar ; make && mv rebar /usr/local/bin/)
@@ -42,12 +44,12 @@ RUN cd /usr/src \
   && git checkout master
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-  && echo 'deb https://deb.nodesource.com/node wheezy main' > /etc/apt/sources.list.d/nodesource.list \
-  && echo 'deb-src https://deb.nodesource.com/node wheezy main' >> /etc/apt/sources.list.d/nodesource.list \
+  && echo 'deb https://deb.nodesource.com/node jessie main' > /etc/apt/sources.list.d/nodesource.list \
+  && echo 'deb-src https://deb.nodesource.com/node jessie main' >> /etc/apt/sources.list.d/nodesource.list \
   && apt-get update -y && apt-get install -y nodejs \
   && npm install -g npm && npm install -g grunt-cli
 
-RUN cd /usr/src/couchdb && ./configure --disable-docs && make
+RUN cd /usr/src/couchdb && ./configure && make
 
 # permissions
 RUN chmod +x /usr/src/couchdb/dev/run && chown -R couchdb:couchdb /usr/src/couchdb


### PR DESCRIPTION
Python sphinx > 1.2.x is only available in jessie so I made the move. 
Doc is building fine but "not found" in fauxton ...

NOTE: I'am really not sure why we keep this :  libssl0.9.8_0.9.8o-4squeeze14_amd64.deb instead of the 1.0.1 available in jessie