### PR TITLE
Reorganize Dockerfile

### DIFF
--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -21,6 +21,8 @@ RUN groupadd -r couchdb && useradd -d /var/lib/couchdb -g couchdb couchdb
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    erlang-nox \
+    libicu52 \
     libmozjs185-1.0 \
     libnspr4 \
     libnspr4-0d \
@@ -54,14 +56,17 @@ RUN set -xe \
 ENV COUCHDB_VERSION 1.6.1
 
 # download dependencies, compile and install couchdb
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    build-essential \
+RUN buildDeps=' \
+    gcc \
+    g++ \
     erlang-dev \
-    erlang-nox \
     libcurl4-openssl-dev \
     libicu-dev \
     libmozjs185-dev \
     libnspr4-dev \
+    make \
+  ' \
+  && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
   && curl -fSL http://apache.osuosl.org/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
   && curl -fSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
   && gpg --verify couchdb.tar.gz.asc \
@@ -70,17 +75,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   && cd /usr/src/couchdb \
   && ./configure --with-js-lib=/usr/lib --with-js-include=/usr/include/mozjs \
   && make && make install \
-  && apt-get purge -y \
-    binutils \
-    build-essential \
-    cpp \
-    libcurl4-openssl-dev \
-    libicu-dev \
-    libnspr4-dev \
-    make \
-    perl \
-  && apt-get autoremove -y \
-  && apt-get install -y libicu52 --no-install-recommends \
+  && apt-get purge -y --auto-remove $buildDeps \
   && rm -rf /var/lib/apt/lists/* /usr/src/couchdb /couchdb.tar.gz* \
   && chown -R couchdb:couchdb \
     /usr/local/lib/couchdb /usr/local/etc/couchdb \

--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -16,34 +16,61 @@ MAINTAINER Clemens Stolle klaemo@apache.org
 
 # Install instructions from https://cwiki.apache.org/confluence/display/COUCHDB/Debian
 
-ENV COUCHDB_VERSION 1.6.1
-
 RUN groupadd -r couchdb && useradd -d /var/lib/couchdb -g couchdb couchdb
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    libmozjs185-1.0 \
+    libnspr4 \
+    libnspr4-0d \
+  && rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root, set correct permissions, expose couchdb to the outside
+# and disable logging to disk
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
+  && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu
+
+# https://www.apache.org/dist/couchdb/KEYS
+ENV GPG_KEYS \
+  15DD4F3B8AACA54740EB78C7B7B7C53943ECCEE1 \
+  1CFBFA43C19B6DF4A0CA3934669C02FFDF3CEBA3 \
+  25BBBAC113C1BFD5AA594A4C9F96B92930380381 \
+  4BFCA2B99BADC6F9F105BEC9C5E32E2D6B065BFB \
+  5D680346FAA3E51B29DBCB681015F68F9DA248BC \
+  7BCCEB868313DDA925DF1805ECA5BCB7BB9656B0 \
+  C3F4DFAEAD621E1C94523AEEC376457E61D50B88 \
+  D2B17F9DA23C0A10991AF2E3D9EE01E47852AEE4 \
+  E0AF0A194D55C84E4A19A801CDB0C0F904F4EE9B
+RUN set -xe \
+  && for key in $GPG_KEYS; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV COUCHDB_VERSION 1.6.1
 
 # download dependencies, compile and install couchdb
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     build-essential \
-    ca-certificates \
-    curl \
     erlang-dev \
     erlang-nox \
     libcurl4-openssl-dev \
     libicu-dev \
-    libmozjs185-1.0 \
     libmozjs185-dev \
-    libnspr4 \
-    libnspr4-0d \
     libnspr4-dev \
- && curl -sSL http://apache.openmirror.de/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
- && curl -sSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
- && curl -sSL https://www.apache.org/dist/couchdb/KEYS -o KEYS \
- && gpg --import KEYS && gpg --verify couchdb.tar.gz.asc \
- && mkdir -p /usr/src/couchdb \
- && tar -xzf couchdb.tar.gz -C /usr/src/couchdb --strip-components=1 \
- && cd /usr/src/couchdb \
- && ./configure --with-js-lib=/usr/lib --with-js-include=/usr/include/mozjs \
- && make && make install \
- && apt-get purge -y \
+  && curl -fSL http://apache.osuosl.org/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+  && curl -fSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
+  && gpg --verify couchdb.tar.gz.asc \
+  && mkdir -p /usr/src/couchdb \
+  && tar -xzf couchdb.tar.gz -C /usr/src/couchdb --strip-components=1 \
+  && cd /usr/src/couchdb \
+  && ./configure --with-js-lib=/usr/lib --with-js-include=/usr/include/mozjs \
+  && make && make install \
+  && apt-get purge -y \
     binutils \
     build-essential \
     cpp \
@@ -52,18 +79,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     libnspr4-dev \
     make \
     perl \
- && apt-get autoremove -y \
- && apt-get install -y libicu52 --no-install-recommends \
- && rm -rf /var/lib/apt/lists/* /usr/src/couchdb /couchdb.tar.gz* /KEYS
-
-# grab gosu for easy step-down from root, set correct permissions, expose couchdb to the outside
-# and disable logging to disk
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture)" \
-  && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.7/gosu-$(dpkg --print-architecture).asc" \
-  && gpg --verify /usr/local/bin/gosu.asc \
-  && rm /usr/local/bin/gosu.asc \
-  && chmod +x /usr/local/bin/gosu \
+  && apt-get autoremove -y \
+  && apt-get install -y libicu52 --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* /usr/src/couchdb /couchdb.tar.gz* \
   && chown -R couchdb:couchdb \
     /usr/local/lib/couchdb /usr/local/etc/couchdb \
     /usr/local/var/lib/couchdb /usr/local/var/log/couchdb /usr/local/var/run/couchdb \
@@ -72,7 +90,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4
     /usr/local/var/lib/couchdb /usr/local/var/log/couchdb /usr/local/var/run/couchdb \
   && mkdir -p /var/lib/couchdb \
   && sed -e 's/^bind_address = .*$/bind_address = 0.0.0.0/' -i /usr/local/etc/couchdb/default.ini \
-  && sed -e 's/\/usr\/local\/var\/log\/couchdb\/couch.log$/\/dev\/null/' -i /usr/local/etc/couchdb/default.ini
+  && sed -e 's!/usr/local/var/log/couchdb/couch.log$!/dev/null!' -i /usr/local/etc/couchdb/default.ini
 
 COPY ./docker-entrypoint.sh /
 


### PR DESCRIPTION
While reviewing this for https://github.com/docker-library/official-images/pull/1288, I figured it might be easier to just make a PR.  I made a couple commits to try to illustrate the reasons for the changes.

- b34eabccc627c3c24fd8872709e8b5fd30e11460 was to reorder a few items like run dependencies, gosu, gpg keys, and user creation to be before the `COUCHDB_VERSION` so that those layers could be cached and possibly shared between versions of CouchDB.
  - I moved the keys to use the long fingerprints so that docker build cache is easier to break when a key gets added or removed from the list.  It also adds an extra layer of security where the getting the key fingerprint is separate from the build process.  The loop is to make it fail if only one key fails to download since gpg only fails if all keys fail.
  - switched to `apache.osuosl.org` for download since that will be closer/faster for the build server.  Is there a proxy that would redirect to the closest mirror?
  - also some whitespace changes to unify to 2 spaces per indent
-  d5952ff4bb15238c20b8c26ca1bc9d7d84b9aa17 helps differentiate build time vs run time dependencies, while also putting the installed build packages into a variable for easier remove after compilation.  Also switch to explicit `gcc`/`g++` rather than `build-essential`, since that is for ["building Debian packages"](https://packages.debian.org/jessie/build-essential).

The size difference isn't much, but it does save a little space:
```console
REPOSITORY          TAG           IMAGE ID            CREATED             VIRTUAL SIZE
couchdb             new           5b373ff7d0d1        About an hour ago   226.4 MB
couchdb             old           dd39277a0793        About an hour ago   231 MB
```