### PR TITLE
Add Dockerfile for production Erlang release

### DIFF
--- a/2.0-prod/Dockerfile
+++ b/2.0-prod/Dockerfile
@@ -50,6 +50,7 @@ RUN cd /usr/src \
 # Now override some of the configuration
 COPY couchdb.config /usr/src/couchdb/rel/
 COPY local.ini /usr/src/couchdb/rel/overlay/etc/
+COPY vm.args /usr/src/couchdb/rel/overlay/etc/
 
 # Build the release and install into /opt
 RUN cd /usr/src/couchdb \
@@ -76,6 +77,8 @@ RUN apt-get purge -y \
 
 USER couchdb
 EXPOSE 5984
+EXPOSE 4369
+EXPOSE 9100
 WORKDIR /opt/couchdb
 
 ENTRYPOINT ["/opt/couchdb/bin/couchdb"]

--- a/2.0-prod/Dockerfile
+++ b/2.0-prod/Dockerfile
@@ -16,6 +16,7 @@ MAINTAINER Clemens Stolle klaemo@apache.org
 
 ENV COUCHDB_VERSION master
 
+
 RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
 
 # Download dependencies
@@ -38,30 +39,20 @@ RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
  && echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list \
  && echo 'deb-src https://deb.nodesource.com/node_4.x jessie main' >> /etc/apt/sources.list.d/nodesource.list \
  && apt-get update -y -qq && apt-get install -y nodejs \
- && npm install -g grunt-cli
-
+ && npm install -g grunt-cli \
 # Acquire and configure CouchDB source code
-RUN cd /usr/src \
+ && cd /usr/src \
  && git clone --depth 1 https://git-wip-us.apache.org/repos/asf/couchdb.git \
  && cd couchdb \
  && git checkout $COUCHDB_VERSION \
- && ./configure --disable-docs
-
-# Now override some of the configuration
-COPY couchdb.config /usr/src/couchdb/rel/
-COPY local.ini /usr/src/couchdb/rel/overlay/etc/
-COPY vm.args /usr/src/couchdb/rel/overlay/etc/
-
+ && ./configure --disable-docs \
 # Build the release and install into /opt
-RUN cd /usr/src/couchdb \
  && make build \
  && mv /usr/src/couchdb/rel/couchdb /opt/ \
  && mkdir -p /var/lib/couchdb \
- && chown -R couchdb:couchdb /opt/couchdb /var/lib/couchdb
-VOLUME ["/var/lib/couchdb"]
-
+ && chown -R couchdb:couchdb /opt/couchdb /var/lib/couchdb \
 # Cleanup build detritus
-RUN apt-get purge -y \
+ && apt-get purge -y \
     binutils \
     build-essential \
     cpp \
@@ -75,6 +66,12 @@ RUN apt-get purge -y \
  && apt-get install -y libicu52 --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* /usr/lib/node_modules /usr/src/couchdb
 
+# Now override some of the configuration
+COPY couchdb.config /usr/src/couchdb/rel/
+COPY local.ini /usr/src/couchdb/rel/overlay/etc/
+COPY vm.args /usr/src/couchdb/rel/overlay/etc/
+
+VOLUME ["/var/lib/couchdb"]
 USER couchdb
 EXPOSE 5984
 EXPOSE 4369

--- a/2.0-prod/Dockerfile
+++ b/2.0-prod/Dockerfile
@@ -45,7 +45,10 @@ RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
  && git clone --depth 1 https://git-wip-us.apache.org/repos/asf/couchdb.git \
  && cd couchdb \
  && git checkout $COUCHDB_VERSION \
- && ./configure --disable-docs \
+ && ./configure \
+    --disable-docs \
+    --databasedir /var/lib/couchdb \
+    --viewindexdir /var/lib/couchdb \
 # Build the release and install into /opt
  && make build \
  && mv /usr/src/couchdb/rel/couchdb /opt/ \
@@ -67,9 +70,9 @@ RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* /usr/lib/node_modules /usr/src/couchdb
 
 # Now override some of the configuration
-COPY couchdb.config /usr/src/couchdb/rel/
-COPY local.ini /usr/src/couchdb/rel/overlay/etc/
-COPY vm.args /usr/src/couchdb/rel/overlay/etc/
+COPY local.ini /opt/couchdb/etc/
+COPY vm.args /opt/couchdb/etc/
+RUN chown couchdb:couchdb /opt/couchdb/etc/*
 
 VOLUME ["/var/lib/couchdb"]
 USER couchdb

--- a/2.0-prod/Dockerfile
+++ b/2.0-prod/Dockerfile
@@ -48,15 +48,16 @@ RUN cd /usr/src \
  && ./configure --disable-docs
 
 # Now override some of the configuration
-COPY couchdb.config /usr/src/couchdb/rel/overlay/
+COPY couchdb.config /usr/src/couchdb/rel/
 COPY local.ini /usr/src/couchdb/rel/overlay/etc/
 
 # Build the release and install into /opt
-RUN make build \
+RUN cd /usr/src/couchdb \
+ && make build \
  && mv /usr/src/couchdb/rel/couchdb /opt/ \
- && mkdir -p /opt/couchdb/data \
- && chown -R couchdb:couchdb /opt/couchdb
-VOLUME ["/opt/couchdb/data"]
+ && mkdir -p /var/lib/couchdb \
+ && chown -R couchdb:couchdb /opt/couchdb /var/lib/couchdb
+VOLUME ["/var/lib/couchdb"]
 
 # Cleanup build detritus
 RUN apt-get purge -y \

--- a/2.0-prod/Dockerfile
+++ b/2.0-prod/Dockerfile
@@ -1,0 +1,73 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+FROM debian:jessie
+
+MAINTAINER Clemens Stolle klaemo@apache.org
+
+ENV COUCHDB_VERSION master
+
+RUN groupadd -r couchdb && useradd -d /opt/couchdb -g couchdb couchdb
+
+# Download dependencies
+RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    curl \
+    erlang-dev \
+    erlang-nox \
+    erlang-reltool \
+    git \
+    haproxy \
+    libcurl4-openssl-dev \
+    libicu-dev \
+    libmozjs185-dev \
+    openssl \
+    python \
+ && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo 'deb https://deb.nodesource.com/node_4.x jessie main' > /etc/apt/sources.list.d/nodesource.list \
+ && echo 'deb-src https://deb.nodesource.com/node_4.x jessie main' >> /etc/apt/sources.list.d/nodesource.list \
+ && apt-get update -y -qq && apt-get install -y nodejs \
+ && npm install -g grunt-cli
+
+# Compile everything and build a relocatable release
+RUN cd /usr/src && git clone --depth 1 https://git-wip-us.apache.org/repos/asf/couchdb.git \
+ && cd couchdb && git checkout $COUCHDB_VERSION \
+ && cd /usr/src/couchdb && ./configure --disable-docs && make build
+
+# Install the release into /opt
+RUN mv /usr/src/couchdb/rel/couchdb /opt/ \
+ && mkdir -p /opt/couchdb/data \
+ && chown -R couchdb:couchdb /opt/couchdb
+VOLUME ["/opt/couchdb/data"]
+
+# Cleanup build detritus
+RUN apt-get purge -y \
+    binutils \
+    build-essential \
+    cpp \
+    erlang-dev \
+    git \
+    libicu-dev \
+    make \
+    nodejs \
+    perl \
+ && apt-get autoremove -y && apt-get clean \
+ && apt-get install -y libicu52 --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/* /usr/lib/node_modules /usr/src/couchdb
+
+USER couchdb
+EXPOSE 5984
+WORKDIR /opt/couchdb
+
+ENTRYPOINT ["/opt/couchdb/bin/couchdb"]

--- a/2.0-prod/Dockerfile
+++ b/2.0-prod/Dockerfile
@@ -40,13 +40,20 @@ RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
  && apt-get update -y -qq && apt-get install -y nodejs \
  && npm install -g grunt-cli
 
-# Compile everything and build a relocatable release
-RUN cd /usr/src && git clone --depth 1 https://git-wip-us.apache.org/repos/asf/couchdb.git \
- && cd couchdb && git checkout $COUCHDB_VERSION \
- && cd /usr/src/couchdb && ./configure --disable-docs && make build
+# Acquire and configure CouchDB source code
+RUN cd /usr/src \
+ && git clone --depth 1 https://git-wip-us.apache.org/repos/asf/couchdb.git \
+ && cd couchdb \
+ && git checkout $COUCHDB_VERSION \
+ && ./configure --disable-docs
 
-# Install the release into /opt
-RUN mv /usr/src/couchdb/rel/couchdb /opt/ \
+# Now override some of the configuration
+COPY couchdb.config /usr/src/couchdb/rel/overlay/
+COPY local.ini /usr/src/couchdb/rel/overlay/etc/
+
+# Build the release and install into /opt
+RUN make build \
+ && mv /usr/src/couchdb/rel/couchdb /opt/ \
  && mkdir -p /opt/couchdb/data \
  && chown -R couchdb:couchdb /opt/couchdb
 VOLUME ["/opt/couchdb/data"]

--- a/2.0-prod/couchdb.config
+++ b/2.0-prod/couchdb.config
@@ -1,0 +1,22 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+%
+{package_author_name, "The Apache Software Foundation"}.
+{prefix, "."}.
+{data_dir, "./data"}.
+{view_index_dir, "./data"}.
+{log_file, ""}.
+{fauxton_root, "./share/www"}.
+{user, "couchdb"}.
+{node_name, "-sname couchdb"}.
+{cluster_port, 5984}.
+{backend_port, 5986}.

--- a/2.0-prod/couchdb.config
+++ b/2.0-prod/couchdb.config
@@ -17,6 +17,5 @@
 {log_file, ""}.
 {fauxton_root, "./share/www"}.
 {user, "couchdb"}.
-{node_name, "-sname couchdb"}.
 {cluster_port, 5984}.
 {backend_port, 5986}.

--- a/2.0-prod/couchdb.config
+++ b/2.0-prod/couchdb.config
@@ -12,8 +12,8 @@
 %
 {package_author_name, "The Apache Software Foundation"}.
 {prefix, "."}.
-{data_dir, "./data"}.
-{view_index_dir, "./data"}.
+{data_dir, "/var/lib/couchdb"}.
+{view_index_dir, "/var/lib/couchdb"}.
 {log_file, ""}.
 {fauxton_root, "./share/www"}.
 {user, "couchdb"}.

--- a/2.0-prod/local.ini
+++ b/2.0-prod/local.ini
@@ -1,0 +1,8 @@
+; CouchDB Configuration Settings
+
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[chttpd]
+bind_address = any

--- a/2.0-prod/vm.args
+++ b/2.0-prod/vm.args
@@ -10,12 +10,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Each node in the system must have a unique name.  A name can be short
-# (specified using -sname) or it can by fully qualified (-name).  There can be
-# no communication between nodes running with the -sname flag and those running 
-# with the -name flag.
-{{node_name}}
-
 # All nodes must share the same magic cookie for distributed Erlang to work.
 # Comment out this line if you synchronized the cookies by other means (using
 # the ~/.erlang.cookie file, for example).

--- a/2.0-prod/vm.args
+++ b/2.0-prod/vm.args
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Each node in the system must have a unique name.  A name can be short
+# (specified using -sname) or it can by fully qualified (-name).  There can be
+# no communication between nodes running with the -sname flag and those running 
+# with the -name flag.
+{{node_name}}
+
+# All nodes must share the same magic cookie for distributed Erlang to work.
+# Comment out this line if you synchronized the cookies by other means (using
+# the ~/.erlang.cookie file, for example).
+-setcookie monster
+
+# Ensure that the Erlang VM listens on a known port
+-kernel inet_dist_listen_min 9100
+-kernel inet_dist_listen_max 9100
+
+# Tell kernel and SASL not to log anything
+-kernel error_logger silent
+-sasl sasl_error_logger false
+
+# Use kernel poll functionality if supported by emulator
++K true
+
+# Start a pool of asynchronous IO threads
++A 16
+
+# Comment this line out to enable the interactive Erlang shell on startup
++Bd -noinput

--- a/2.0-prod/vm.args
+++ b/2.0-prod/vm.args
@@ -10,11 +10,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# All nodes must share the same magic cookie for distributed Erlang to work.
-# Comment out this line if you synchronized the cookies by other means (using
-# the ~/.erlang.cookie file, for example).
--setcookie monster
-
 # Ensure that the Erlang VM listens on a known port
 -kernel inet_dist_listen_min 9100
 -kernel inet_dist_listen_max 9100


### PR DESCRIPTION
Unlike the 2.0-dev build, which results in a fully-connected 3 node cluster inside the container, this Dockerfile builds a minimal Erlang release using reltool, installs that release into /opt/couchdb, and runs just the one single Erlang VM. Orchestrating a cluster of these is out of scope.

I'm neither a Debian nor a Dockerfile pro at this point, and there are certainly some idiosyncrasies to work out. Nevertheless, this seems like a good start down a path towards a Docker build for running 2.0 in production. What do you think?