### PR TITLE
Don't use VOLUME in the Dockerfile

### DIFF
--- a/1.6.1/Dockerfile
+++ b/1.6.1/Dockerfile
@@ -96,9 +96,6 @@ RUN buildDeps=' \
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 
-# Define mountable directories.
-VOLUME ["/usr/local/var/lib/couchdb"]
-
 EXPOSE 5984
 WORKDIR /var/lib/couchdb
 


### PR DESCRIPTION
The VOLUME command is irreversible and makes it impossible to pre-fill the database. It's better to document the folder in the README instead of using the command.