### PR TITLE
Fix couchdb2-single image

### DIFF
--- a/2.0-single/Dockerfile
+++ b/2.0-single/Dockerfile
@@ -16,7 +16,7 @@ MAINTAINER Clemens Stolle klaemo@apache.org
 
 # Pin to an arbitrary commit for a deterministic build
 # Once CouchDB has an actual 2.0 tag, we can use that
-ENV COUCHDB_VERSION 1b38ccd
+ENV COUCHDB_VERSION 1b38ccd0294ad17d719655612b14b00160168dfd
 
 # Download dependencies
 RUN apt-get update -y -qq \

--- a/2.0-single/Dockerfile
+++ b/2.0-single/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update -y -qq \
  && npm install -g grunt-cli \
  # Acquire CouchDB source code
  && cd /usr/src \
- && git clone --depth 1 https://git-wip-us.apache.org/repos/asf/couchdb.git \
+ && git clone --single-branch https://git-wip-us.apache.org/repos/asf/couchdb.git \
  && cd couchdb \
  && git checkout $COUCHDB_VERSION \
  # Build the release and install into /opt


### PR DESCRIPTION
@klaemo This fixes the issue with the previous build.

The problem was that the original `git clone` code did a shallow clone, which only grabbed the one latest commit. When I changed the `COUCHDB_VERSION` to a commit ID, it failed after that commit was no longer the latest commit (since that commit would not be in the shallow clone).

This now no longer does a shallow commit (so it is slower), but still uses `--single-branch` so it doesn't perform as poorly as a complete clone. I've tested this updated build and it appears to work again.