### PR TITLE
1.6: allow admin user/password special chars (#60)

### DIFF
--- a/1.6.1/docker-entrypoint.sh
+++ b/1.6.1/docker-entrypoint.sh
@@ -32,7 +32,7 @@ if [ "$1" = 'couchdb' ]; then
 
 	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
 		# Create admin
-		printf "[admins]\n$COUCHDB_USER = $COUCHDB_PASSWORD\n" > /usr/local/etc/couchdb/local.d/docker.ini
+		printf "[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" > /usr/local/etc/couchdb/local.d/docker.ini
 		chown couchdb:couchdb /usr/local/etc/couchdb/local.d/docker.ini
 	fi
 


### PR DESCRIPTION
Using the % symbol is reserved in the printf format string