### PR TITLE
Added environment-based admin user/pass

### DIFF
--- a/2.0.0/docker-entrypoint.sh
+++ b/2.0.0/docker-entrypoint.sh
@@ -22,6 +22,30 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	chmod 664 /opt/couchdb/etc/*.ini
 	chmod 775 /opt/couchdb/etc/*.d
 
+	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
+		# Create admin
+		printf "[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" > /opt/couchdb/etc/local.d/docker.ini
+		chown couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini
+	fi
+
+	# if we don't find an [admins] section followed by a non-comment, display a warning
+	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/docker.ini; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: CouchDB is running in Admin Party mode.
+			         This will allow anyone with access to the
+			         CouchDB port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
+			         Use "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
+			         to set it in "docker run".
+			****************************************************
+		EOWARN
+	fi
+
+
 	exec gosu couchdb "$@"
 fi
 


### PR DESCRIPTION
Added COUCHDB_USER and COUCHDB_PASS from the 1.6.1 version and adjusted the
file locations to reflect the new 2.0.0 locations