### PR TITLE
Relax CouchDB v2 entry point ini

### DIFF
--- a/2.0.0/docker-entrypoint.sh
+++ b/2.0.0/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	fi
 
 	# if we don't find an [admins] section followed by a non-comment, display a warning
-	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/docker.ini; then
+	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)
 		cat >&2 <<-'EOWARN'
 			****************************************************


### PR DESCRIPTION
`admins` could be set in any ini file, so allow it.
