### PR TITLE
Add COUCHDB_HTTP_PORT/BIND_ADDRESS to 1.6.1

### DIFF
--- a/1.6.1/docker-entrypoint.sh
+++ b/1.6.1/docker-entrypoint.sh
@@ -36,6 +36,9 @@ if [ "$1" = 'couchdb' ]; then
 		chown couchdb:couchdb /usr/local/etc/couchdb/local.d/docker.ini
 	fi
 
+	printf "[httpd]\nport = %s\nbind_address = %s\n" ${COUCHDB_HTTP_PORT:=5984} ${COUCHDB_HTTP_BIND_ADDRESS:=0.0.0.0} > /usr/local/etc/couchdb/local.d/bind_address.ini
+	chown couchdb:couchdb /usr/local/etc/couchdb/local.d/bind_address.ini
+
 	# if we don't find an [admins] section followed by a non-comment, display a warning
 	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /usr/local/etc/couchdb; then
 		# The - option suppresses leading tabs but *not* spaces. :)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ curl http://localhost:5984
 If you want to provide your own config, you can either mount a directory at `/usr/local/etc/couchdb`
 or extend the image and `COPY` your `config.ini` (see [Build you own](#build-your-own)).
 
+If you need (or want) to run couchdb in `net=host` mode, you can customize the port and bind address using environment variables:
+
+ - `COUCHDB_HTTP_BIND_ADDRESS` (default: `0.0.0.0`)
+ - `COUCHDB_HTTP_PORT` (default: `5984`)
+
 ### with couchperuser plugin
 
 This build includes the `couchperuser` plugin.


### PR DESCRIPTION
COUCHDB_HTTP_PORT and COUCHDB_HTTP_BIND_ADDRESS allow to customize the address and port couchdb is listening at. It comes handy in net=host mode.

Defaults to 0.0.0.0:5984 (so it's a 100% backward compatible change)