### PR TITLE
Dockerfile puts local.ini in /opt/couchdb/etc/, not local.d.

### DIFF
--- a/2.0.0/Dockerfile
+++ b/2.0.0/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* /usr/lib/node_modules /usr/src/couchdb*
 
 # Add configuration
-COPY local.ini /opt/couchdb/etc/
+COPY local.ini /opt/couchdb/etc/local.d/
 COPY vm.args /opt/couchdb/etc/
 
 COPY ./docker-entrypoint.sh /

--- a/2.0.0/Dockerfile
+++ b/2.0.0/Dockerfile
@@ -90,7 +90,7 @@ COPY ./docker-entrypoint.sh /
 
 # Setup directories and permissions
 RUN chmod +x /docker-entrypoint.sh \
- && mkdir /opt/couchdb/data /opt/couchdb/etc/local.d /opt/couchdb/etc/default.d \
+ && mkdir /opt/couchdb/data /opt/couchdb/etc/default.d \
  && chown -R couchdb:couchdb /opt/couchdb/
 
 WORKDIR /opt/couchdb

--- a/2.0.0/docker-entrypoint.sh
+++ b/2.0.0/docker-entrypoint.sh
@@ -33,7 +33,7 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	fi
 
 	# if we don't find an [admins] section followed by a non-comment, display a warning
-	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/*.ini; then
+	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)
 		cat >&2 <<-'EOWARN'
 			****************************************************

--- a/2.0.0/docker-entrypoint.sh
+++ b/2.0.0/docker-entrypoint.sh
@@ -20,6 +20,7 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	chmod -R 0770 /opt/couchdb/data
 
 	chmod 664 /opt/couchdb/etc/*.ini
+	chmod 664 /opt/couchdb/etc/local.d/*.ini
 	chmod 775 /opt/couchdb/etc/*.d
 
 	if [ ! -z "$NODENAME" ] && ! grep "couchdb@" /opt/couchdb/etc/vm.args; then
@@ -33,7 +34,7 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 	fi
 
 	# if we don't find an [admins] section followed by a non-comment, display a warning
-	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/*.ini; then
+	if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/local.d/*.ini; then
 		# The - option suppresses leading tabs but *not* spaces. :)
 		cat >&2 <<-'EOWARN'
 			****************************************************

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Example Dockerfile:
 ```
 FROM klaemo/couchdb:latest
 
-COPY local.ini /usr/local/etc/couchdb/
+COPY local.ini /usr/local/etc/couchdb/local.d/
 ```
 
 and then build and run


### PR DESCRIPTION
The admin part warning always appears, because it is looking for `local.ini` in the wrong place.

The [Dockerfile](https://github.com/klaemo/docker-couchdb/blob/master/2.0.0/Dockerfile#L86) puts `local.ini` in `/opt/couchdb/etc/`, not /opt/couchdb/etc/local.d/`, so I think this would be the correct place to look for the *.ini.