### PR TITLE
Needed a way to map internal container UID/GID to external ones. Adde…

### DIFF
--- a/1.6.1/docker-entrypoint.sh
+++ b/1.6.1/docker-entrypoint.sh
@@ -14,6 +14,16 @@
 set -e
 
 if [ "$1" = 'couchdb' ]; then
+	# map user UID and group GID's back to parent system
+	# useful for using persistent volumes and preserving id mappings
+	if [ "$COUCHDB_UID" ]; then
+		usermod -o -u $COUCHDB_UID couchdb
+	fi
+
+	if [ "$COUCHDB_GID" ]; then
+		groupmod -o -g $COUCHDB_GID couchdb
+	fi
+
 	# we need to set the permissions here because docker mounts volumes as root
 	chown -R couchdb:couchdb \
 		/usr/local/var/lib/couchdb \

--- a/2.0.0/docker-entrypoint.sh
+++ b/2.0.0/docker-entrypoint.sh
@@ -14,6 +14,16 @@
 set -e
 
 if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
+	# map user UID and group GID's back to parent system
+	# useful for using persistent volumes and preserving id mappings
+	if [ "$COUCHDB_UID" ]; then
+		usermod -o -u $COUCHDB_UID couchdb
+	fi
+
+	if [ "$COUCHDB_GID" ]; then
+		groupmod -o -g $COUCHDB_GID couchdb
+	fi
+
 	# we need to set the permissions here because docker mounts volumes as root
 	chown -R couchdb:couchdb /opt/couchdb
 


### PR DESCRIPTION
Added two variables (COUCHDB_UID & COUCHDB_GID) to enable manually setting the user and group ID's for all of the couchdb files. This helps map the internal couchdb user & group ID's to map to the original system's IDs. 

Our team is using the docker container to setup local couchdb instances for our data engineers and software devs. The data files often live in their home directory, so a  pseudo-random user/group ID's didn't work too well. 
